### PR TITLE
Set "keep_screen_on" setting variable to false

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -81,6 +81,7 @@ window/size/test_height=1
 window/dpi/allow_hidpi=true
 window/per_pixel_transparency/allowed=true
 window/per_pixel_transparency/enabled=true
+window/energy_saving/keep_screen_on=false
 
 [gdnative]
 


### PR DESCRIPTION
Currently, when this launcher is open, it will prevent a computer from shutting off its screen, or going to sleep.

This is desirable for games, but this isn't a game itself, so I feel that it is not a desirable behavior here.