### PR TITLE
[Windows] Main display turns black while maximised application is act…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Dabdoob.exe
 
 # Godot Git plugin
 /bin
+/build
 git_api.gdnlib
 git_api.gdns
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.14)
+project(win32_helper LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# 1. Output compiled binary directly into bin/ dir
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+
+# 2. download godot-cpp bindings (3.6 / 3.x branch) if missing
+include(FetchContent)
+
+FetchContent_Declare(
+    godot-cpp
+    GIT_REPOSITORY https://github.com/godotengine/godot-cpp.git
+    GIT_TAG        3.6 # Targets Godot 3.6, update if required if project migrates to godot 4 or later.
+)
+
+# Fetch and build godot-cpp in background
+FetchContent_MakeAvailable(godot-cpp)
+
+# 3. Create the shared library target (.dll on Windows, .so on linux)
+add_library(win32_helper SHARED
+    native/win32_helper.cpp
+)
+
+# 4. Link against fetched godot-cpp library
+target_link_libraries(win32_helper PRIVATE godot-cpp)
+
+# 5. platform specific linking
+if(WIN32)
+    # Link Windows system API library for SPI_GETWORKAREA
+    target_link_libraries(win32_helper PRIVATE user32)
+
+    # Static runtime linking for MinGW GCC
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_link_options(win32_helper PRIVATE -static -static-libgcc -static-libstdc++)
+    endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(win32_helper PRIVATE godot-cpp)
 
 # 5. platform specific linking
 if(WIN32)
-    # Link Windows system API library for SPI_GETWORKAREA
+    # Link Windows system API library for MonitorFromPoint / GetMonitorInfoW
     target_link_libraries(win32_helper PRIVATE user32)
 
     # Static runtime linking for MinGW GCC

--- a/README.md
+++ b/README.md
@@ -41,6 +41,58 @@ None required. The launcher is a single, self-contained executable. Just [downlo
 
  - You only need to disable gatekeeper for Dabdoob, or disable it altogether. Check this guide for more information: https://disable-gatekeeper.github.io/
 
+## Building from Source
+
+The native Windows helper module requires **CMake 3.14+**, a **C++ compiler supporting C++14 or later**, and Python 3.6+ to build.
+Without the native helper module, Dabdoob will still run, but it will not be able to detect the work area of the screen on Windows, which may result in the launcher being partially off-screen on some monitors and the taskbar being hidden behind the launcher window. The native helper module is not required on Linux or macOS.
+
+### Prerequisites
+
+**All platforms:**
+- CMake 3.14 or later: [Download here](https://cmake.org/download/)
+- Python 3.6 or later: [Download here](https://www.python.org/downloads/)
+
+**Windows:**
+- Build tools for visual studio (MSVC) or MinGW-w64. The easiest way to get this is to install Visual Studio Community Edition with the "Desktop development with C++" workload.
+  - [Download Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (free)
+    - Or via winget in terminal: `winget install Microsoft.VisualStudio.2022.Community`winget
+  - Or just the [Build Tools for Visual Studio](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
+  - Or via winget in terminal: `winget install Microsoft.VisualStudio.2022.BuildTools`
+- Install CMake and Python via winget:
+  ```powershell
+  winget install Kitware.CMake
+  winget install Python.Python.3.11
+  # or if you want a whole Python distribution with conda, you can install Miniconda3:
+  winget install Anaconda.Miniconda3
+  ```
+
+**Linux:**
+- GCC 5.0+ or Clang 3.4+
+  - **Debian/Ubuntu:** `sudo apt install build-essential cmake python3`
+  - **Arch:** `sudo pacman -S base-devel cmake python`
+  - **Fedora:** `sudo dnf install gcc gcc-c++ cmake python3`
+
+**macOS:**
+- Xcode Command Line Tools: `xcode-select --install`
+- Homebrew (optional but recommended): `brew install cmake python3`
+
+### Build Instructions
+
+```bash
+# Navigate to the project root
+cd /path/to/Catapult_Dabdoob
+
+# Run the build script
+py ./build.py
+```
+
+This will:
+1. Create a `build/` directory with CMake configuration
+2. Compile native helper modules (x64)
+3. Output the DLL to `bin/Release/win32_helper.dll`
+
+The compiled DLL will be automatically picked up by Godot when you run the project.
+
 ## System requirements
 
 - 64-bit operating system.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Without the native helper module, Dabdoob will still run, but it will not be abl
 **Windows:**
 - Build tools for visual studio (MSVC) or MinGW-w64. The easiest way to get this is to install Visual Studio Community Edition with the "Desktop development with C++" workload.
   - [Download Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (free)
-    - Or via winget in terminal: `winget install Microsoft.VisualStudio.2022.Community`winget
+    - Or via winget in terminal: `winget install Microsoft.VisualStudio.2022.Community`
   - Or just the [Build Tools for Visual Studio](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
   - Or via winget in terminal: `winget install Microsoft.VisualStudio.2022.BuildTools`
 - Install CMake and Python via winget:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Without the native helper module, Dabdoob will still run, but it will not be abl
 cd /path/to/Catapult_Dabdoob
 
 # Run the build script
-py ./build.py
+python ./build.py
 ```
 
 This will:

--- a/build.py
+++ b/build.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import sys
+
+def build():
+    # 1. Create build directory safely
+    os.makedirs("build", exist_ok=True)
+
+    print("--- 1/2: Configuring CMake ---")
+    config_result = subprocess.run(["cmake", "-B", "build", ".", "-DCMAKE_BUILD_TYPE=Release"])
+    if config_result.returncode != 0:
+        print("Error: CMake configuration failed. Make sure CMake and a compiler are installed.")
+        sys.exit(1)
+
+    print("\n--- 2/2: Building C++ Target ---")
+    build_result = subprocess.run(["cmake", "--build", "build", "--config", "Release"])
+    if build_result.returncode != 0:
+        print("Error: Compilation failed.")
+        sys.exit(1)
+
+    print("\nBuild successful")
+
+if __name__ == "__main__":
+    build()

--- a/native/Win32Helper.gdns
+++ b/native/Win32Helper.gdns
@@ -1,0 +1,10 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[sub_resource type="GDNativeLibrary" id=1]
+entry/Windows.64 = "res://bin/Release/win32_helper.dll"
+dependency/Windows.64 = [  ]
+
+[resource]
+resource_name = "Win32Helper"
+class_name = "Win32Helper"
+library = SubResource( 1 )

--- a/native/win32_helper.cpp
+++ b/native/win32_helper.cpp
@@ -1,0 +1,57 @@
+#include <Godot.hpp>
+#include <Reference.hpp>
+#include <windows.h>
+
+namespace godot {
+
+class Win32Helper : public Reference {
+    GODOT_CLASS(Win32Helper, Reference)
+
+public:
+    static void _register_methods() {
+        register_method("get_work_area_for_point", &Win32Helper::get_work_area_for_point);
+    }
+
+    void _init() {}
+
+    // Returns the taskbar-aware work area of the monitor containing (x, y)
+    Rect2 get_work_area_for_point(int x, int y) {
+        POINT pt = { x, y };
+        HMONITOR monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+        MONITORINFO info = {};
+        info.cbSize = sizeof(MONITORINFO);
+        if (GetMonitorInfoW(monitor, &info)) {
+            real_t rx = static_cast<real_t>(info.rcWork.left);
+            real_t ry = static_cast<real_t>(info.rcWork.top);
+            real_t rw = static_cast<real_t>(info.rcWork.right - info.rcWork.left);
+            real_t rh = static_cast<real_t>(info.rcWork.bottom - info.rcWork.top);
+            return Rect2(rx, ry, rw, rh);
+        }
+
+        // Fallback: return empty Rect2 if Win32 call fails
+        return Rect2();
+    }
+};
+
+} // namespace
+
+// Explicitly define the export macro so MSVC knows what to do with it, else I get syntax errors, missing type specifiers, etc.
+#ifdef _WIN32
+#define WIN32_EXPORT __declspec(dllexport)
+#else
+#define WIN32_EXPORT
+#endif
+
+// Notice how WIN32_EXPORT is placed BEFORE 'void'
+extern "C" WIN32_EXPORT void godot_gdnative_init(godot_gdnative_init_options *o) {
+    godot::Godot::gdnative_init(o);
+}
+
+extern "C" WIN32_EXPORT void godot_gdnative_terminate(godot_gdnative_terminate_options *o) {
+    godot::Godot::gdnative_terminate(o);
+}
+
+extern "C" WIN32_EXPORT void godot_nativescript_init(void *handle) {
+    godot::Godot::nativescript_init(handle);
+    godot::register_class<godot::Win32Helper>();
+}

--- a/scripts/CustomTitleBar.gd
+++ b/scripts/CustomTitleBar.gd
@@ -22,7 +22,11 @@ onready var minimize_button = $MarginContainer/HBoxContainer/MinimizeButton
 func _ready() -> void:
 	# Load Windows native DLL if on Windows platform
 	if OS.get_name() == "Windows":
-		win32_helper = preload("res://bin/Win32Helper.gdns").new()
+		var helper_gdns_path = "res://native/Win32Helper.gdns"
+		if ResourceLoader.exists(helper_gdns_path):
+			var helper_class = load(helper_gdns_path)
+			if helper_class:
+				win32_helper = helper_class.new()
 	
 	# Load and set the window icon
 	var app_icon = load("res://icons/appiconpng.png")

--- a/scripts/CustomTitleBar.gd
+++ b/scripts/CustomTitleBar.gd
@@ -10,6 +10,7 @@ var window_start_position := Vector2.ZERO
 var is_maximized := false
 var unmaximized_position := Vector2.ZERO
 var unmaximized_size := Vector2.ZERO
+var win32_helper = null
 
 onready var title_label = $MarginContainer/HBoxContainer/Title
 onready var icon = $MarginContainer/HBoxContainer/Icon
@@ -19,6 +20,10 @@ onready var minimize_button = $MarginContainer/HBoxContainer/MinimizeButton
 
 
 func _ready() -> void:
+	# Load Windows native DLL if on Windows platform
+	if OS.get_name() == "Windows":
+		win32_helper = preload("res://bin/Win32Helper.gdns").new()
+	
 	# Load and set the window icon
 	var app_icon = load("res://icons/appiconpng.png")
 	if app_icon:
@@ -105,27 +110,53 @@ func _on_MaximizeButton_pressed() -> void:
 
 func _toggle_maximize() -> void:
 	if is_maximized:
-		# Restore
+		# window
 		OS.window_position = unmaximized_position
 		OS.window_size = unmaximized_size
 		is_maximized = false
 		maximize_button.texture_normal = maximize_icon
 	else:
-		# Maximize to work area (respects taskbar, like File Explorer)
+		# maximise
 		unmaximized_position = OS.window_position
 		unmaximized_size = OS.window_size
 		is_maximized = true
 		maximize_button.texture_normal = restore_icon
-		var screen_idx := OS.get_current_screen()
-		var work_area: Rect2 = OS.get_screen_work_area(screen_idx)
-		if work_area.size.x > 100 and work_area.size.y > 100:
-			OS.window_position = work_area.position
-			OS.window_size = work_area.size
+		
+		# OS specific maximise logic
+		if OS.get_name() == "Windows":
+			var work_area: Rect2 = get_current_window_work_area_windows()
+			
+			if work_area.size.x > 100 and work_area.size.y > 100:
+				OS.window_position = work_area.position
+				# Subtract 1 pixel to prevent Godot 3 from forcing exclusive fullscreen
+				print("subtract 1 pixel")
+				OS.window_size = Vector2(work_area.size.x, work_area.size.y - 1)
+			else:
+				print("screen size small")
+				var screen_idx := OS.get_current_screen()
+				OS.window_position = OS.get_screen_position(screen_idx)
+				OS.window_size = OS.get_screen_size(screen_idx)
 		else:
-			# get_screen_work_area returned a bad rect (can occur with borderless windows);
-			# fall back to full screen size — may overlap taskbar but won't vanish
+			# macOS / Linux fallback
+			print("mac/linux fallback")
+			var screen_idx := OS.get_current_screen()
 			OS.window_position = OS.get_screen_position(screen_idx)
 			OS.window_size = OS.get_screen_size(screen_idx)
+
+
+func get_current_window_work_area_windows() -> Rect2:
+	# Target screen using window center point
+	var win_center = OS.window_position + (OS.window_size / 2.0)
+	
+	# Call native DLL to get taskbar-aware work area for the monitor at this point
+	if win32_helper:
+		var work_area = win32_helper.get_work_area_for_point(int(win_center.x), int(win_center.y))
+		if work_area.size.x > 0 and work_area.size.y > 0:
+			return work_area
+	
+	# Fallback if DLL is unavailable or returns empty Rect2
+	var screen_idx = OS.get_current_screen()
+	return Rect2(OS.get_screen_position(screen_idx), OS.get_screen_size(screen_idx))
 
 
 func _on_CloseButton_pressed() -> void:

--- a/scripts/CustomTitleBar.gd
+++ b/scripts/CustomTitleBar.gd
@@ -133,16 +133,14 @@ func _toggle_maximize() -> void:
 			if work_area.size.x > 100 and work_area.size.y > 100:
 				OS.window_position = work_area.position
 				# Subtract 1 pixel to prevent Godot 3 from forcing exclusive fullscreen
-				print("subtract 1 pixel")
+				
 				OS.window_size = Vector2(work_area.size.x, work_area.size.y - 1)
 			else:
-				print("screen size small")
 				var screen_idx := OS.get_current_screen()
 				OS.window_position = OS.get_screen_position(screen_idx)
 				OS.window_size = OS.get_screen_size(screen_idx)
 		else:
 			# macOS / Linux fallback
-			print("mac/linux fallback")
 			var screen_idx := OS.get_current_screen()
 			OS.window_position = OS.get_screen_position(screen_idx)
 			OS.window_size = OS.get_screen_size(screen_idx)


### PR DESCRIPTION
Fixes #193

Got black screen on my main display unlike any other game or app when I tried to maximize this application on my main display.
Clicking to another active app on another display rectifies the issue and lets me see the full screen app on main display.
Closing the app also rectifies the issue.
I suspect root cause is something like an overlay causing issues or Nvidia driver fault with this version of Godot engine so I am currently unable to fix.

Workaround is to remove a single pixel from windows y axis while "maximized" to prevent the app being treated as full screen.

In the process I discovered code for maximizing window depended on a non existent call and was non functional for standard Godot engine (see issue #193 for details).

Attempts to use PowerShell to get taskbar existence and definitions, but that will raise alerts with antivirus software.
Implemented a GDNative C++ implementation that does the same thing, is more efficient than throwing commands at powershell and should not raise alerts.
But it does add CMake + a compiler as a dependency, so added instructions for windows, linux and macOS to compile the windows dll and download the Godot tooling required from their official GitHub repo specific to Godot 3.6.

The generated dll is not required for usage, releases or testing and has been implemented as a soft requirement. It exists only to mitigate this issue.

Add Windows native helper module and build instructions
- Introduced a C++ helper module for Windows to manage window positioning.
- Updated README with build prerequisites and instructions for Windows and other operating systems.
- Added a Python build script to automate the CMake configuration and compilation process.
- Enhanced the custom title bar script to utilize the new native helper for taskbar-aware window management.
- Updated .gitignore to include build directory.